### PR TITLE
fix: 아이콘 컴포넌트 속성 오류 핫픽스

### DIFF
--- a/src/components/atoms/Icon.js
+++ b/src/components/atoms/Icon.js
@@ -33,14 +33,14 @@ function Icon({ className, variant, color, css }) {
 
 Icon.defaultProps = {
   className: 'far fa-user-circle fa-lg',
-  variant: theme.iconVariant.ME,
+  variant: theme.fontSize.ME,
   css: emotionCss({}),
   color: theme.color.MAFIA_WHITE,
 };
 
 Icon.propTypes = {
   className: PropTypes.string,
-  variant: PropTypes.oneOf(Object.keys(theme.iconVariant)),
+  variant: PropTypes.oneOf(Object.keys(theme.fontSize)),
   css: PropTypes.objectOf(emotionCss),
   color: PropTypes.oneOf(Object.keys(theme.color)),
 };


### PR DESCRIPTION
iconVariant 변수가 theme에서 사라지면서 이를 사용하는 Icon 컴포넌트에서 prop 수정